### PR TITLE
User can now choose initial distance between bunch head and undulator

### DIFF
--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -823,6 +823,7 @@ namespace MITHRA
     lu_		= 0.0;
     rb_		= 0.0;
     length_		= 0.0;
+    dist_		= 0.0;
     beta_		= 0.0;
     gamma_		= 1.0;
     dt_		= 0.0;

--- a/src/classes.h
+++ b/src/classes.h
@@ -315,6 +315,9 @@ namespace MITHRA
     /* The length of the undulator.									*/
     unsigned int			length_;
 
+    /* The initial distance between the bunch head and the undulator begin.						*/
+    Double				dist_;
+    
     /* The normalized velocity and the equivalent gamma of the undulator movement.			*/
     Double				beta_;
     Double				gamma_;

--- a/src/datainput.cpp
+++ b/src/datainput.cpp
@@ -421,6 +421,7 @@ namespace MITHRA
 		  else if (parameterName(*iter) == "period")                            undulator.lu_           = doubleValue(*iter);
 		  else if (parameterName(*iter) == "polarization-angle")                undulator.theta_        = PI / 180.0 * doubleValue(*iter);
 		  else if (parameterName(*iter) == "length")                            undulator.length_       = intValue(*iter);
+          else if (parameterName(*iter) == "distance-to-bunch-head")            undulator.dist_         = doubleValue(*iter);
 		  else if (parameterName(*iter) == "offset")                            undulator.rb_       	= doubleValue(*iter);
 		  else { std::cout << parameterName(*iter) << " is not defined in the static-undulator group." << std::endl; exit(1); }
 		  ++iter;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -257,17 +257,19 @@ namespace MITHRA
      * section. For optical undulator such a separation should be considered in the input parameters
      * where offset is given.										*/
 
-    /* This shift in time makes sure that the maximum z in the bunch at time zero is 2 undulator
-     * periods away from the undulator begin.								*/
-    dt_ 		= - 1.0 / ( beta_ * undulator_[0].c0_ ) * ( zmax + 2.0 * undulator_[0].lu_ / gamma_ );
+    /* This shift in time makes sure that the maximum z in the bunch at time zero is at undulator[0].dist_ 
+     * away from the undulator begin ( the default distance is 2 undulator periods)			*/
+    if (undulator_[0].dist_ == 0.0) undulator_[0].dist_ = 2.0 * undulator_[0].lu_;
+    dt_ 		= - 1.0 / ( beta_ * undulator_[0].c0_ ) * ( zmax + undulator_[0].dist_ / gamma_ );
+    printmessage(std::string(__FILE__), __LINE__, std::string("Initial distance from bunch head to undulator is ") + stringify(undulator_[0].dist_) );
 
     /* The same shift in time should also be done for the seed field.					*/
     seed_.dt_		= dt_;
 
     /* With the above definition in the time begin the entrance of the undulator, i.e. z = 0 in the lab
-     * frame, corresponds to the z = zmax + 2.0 * undulator_[0].lu_ / gamma_ in the bunch rest frame at
+     * frame, corresponds to the z = zmax + undulator_[0].dist_ / gamma_ in the bunch rest frame at
      * the initialization instant, i.e. timeBunch = 0.0.						*/
-    bunch_.zu_ 	= zmax + 2.0 * undulator_[0].lu_ / gamma_;
+    bunch_.zu_ 	= zmax + undulator_[0].dist_ / gamma_;
     bunch_.beta_ 	= beta_;
 
     printmessage(std::string(__FILE__), __LINE__, std::string("The given parameters are boosted into the electron rest frame :::") );


### PR DESCRIPTION
Before approving the pull request, the refcard and manual need to be modified.
The name in the jobfile for this parameter is `distance-to-bunch-head`. We can choose another better name maybe.

closes #10 